### PR TITLE
feat: DEVOPS-1150 removing legacy-multisig domain

### DIFF
--- a/projects/multi-sig-wallet/project.md
+++ b/projects/multi-sig-wallet/project.md
@@ -4,7 +4,7 @@ description: Multisig wallet backed by a Scilla contract
 categories: wallet
 status: Live
 twitter: False
-website: https://legacy-multisig.zilliqa.com/
+website: https://multisig.zilliqa.com/
 discord: False
 telegram: False
 ---


### PR DESCRIPTION
As removing the domain legacy-multisig.zilliqa.com we are switching the URL to multisig.zilliqa.com.